### PR TITLE
Fix malformed URL on Windows platform

### DIFF
--- a/lib/tools/method.js
+++ b/lib/tools/method.js
@@ -52,7 +52,7 @@ proto.__launch = function LaunchMethod(app, cfg) {
   var self = this,
       method = this._method,
       corsFn = this.__createCors(cfg.cors),
-      route = path.join(cfg.base || '/api', this._entity._route);
+      route = path.join(cfg.base || '/api', this._entity._route).replace(/\\/g, '/');
 
   debug('Launching `%s` method for `%s` entity. cors=%s',
         method, route, !!cfg.cors);


### PR DESCRIPTION
## Normalize forward slashes.

On Windows, path.join concatenates strings using backslashes, this creates invalid routes in express. I've used regex to replace these after the concatenation takes place.

I notice in entity.js there is `tools.join`, which is used by the `url()` method. Perhaps it would be good to break out these utility functions so that both method.js and entity.js use them. That's a bigger design decision though and I didn't wish this simple fix to be a large commit.

Josh.